### PR TITLE
Fix duplicate recorded parameters in dialog

### DIFF
--- a/src/main/java/de/biomedical_imaging/ij/trajectory_classifier/TraJClassifier_.java
+++ b/src/main/java/de/biomedical_imaging/ij/trajectory_classifier/TraJClassifier_.java
@@ -188,9 +188,9 @@ public class TraJClassifier_ implements PlugIn {
 			gd.addNumericField("Pixelsize (µm)**", pixelsize, 4);
 			gd.addNumericField("Framerate (FPS)", 1/timelag, 0);
 			gd.addCheckbox("Use reduced model confined motion", useReducedModelConfinedMotion);
-			gd.addCheckbox("Show IDs", showID);
-			gd.addCheckbox("Show overview classes", showOverviewClasses);
-			gd.addCheckbox("Remove global drift", removeGlobalDrift);
+			gd.addCheckbox("Show_IDs", showID);
+			gd.addCheckbox("Show_overview classes", showOverviewClasses);
+			gd.addCheckbox("Remove_global_drift", removeGlobalDrift);
 			gd.addMessage("* The ratio of window size / resample rate have to be at least 30.");
 			gd.addMessage("** Set to zero if the imported data is already correctly scaled.");
 			gd.addHelp("http://imagej.net/TraJClassifier");

--- a/src/main/java/de/biomedical_imaging/ij/trajectory_classifier/TraJClassifier_.java
+++ b/src/main/java/de/biomedical_imaging/ij/trajectory_classifier/TraJClassifier_.java
@@ -181,9 +181,9 @@ public class TraJClassifier_ implements PlugIn {
 			//Show GUI
 			GenericDialog gd = new GenericDialog("TraJectory Classification ("+classifierVersion+")");
 		
-			gd.addSlider("Min. tracklength", 10, 1000, minTrackLength);
-			gd.addSlider("Windowsize (positions)", 10, 1000, windowSizeClassification);
-			gd.addSlider("Min. segment length",10,1000,minSegmentLength);
+			gd.addSlider("Min._track_length", 10, 1000, minTrackLength);
+			gd.addSlider("Window_size (positions)", 10, 1000, windowSizeClassification);
+			gd.addSlider("Min._segment_length",10,1000,minSegmentLength);
 			gd.addNumericField("Resample rate*", resampleRate, 0);
 			gd.addNumericField("Pixelsize (µm)**", pixelsize, 4);
 			gd.addNumericField("Framerate (FPS)", 1/timelag, 0);


### PR DESCRIPTION
When using the macro recorder while running TraJectory Classifier in ImageJ, the presence of two _show_ parameters led to an error. This commit fixes the issue by introducing underscores for the parameters, thereby also making the recorded command more readable.